### PR TITLE
switch base for build container to official openshift golang image

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM    golang:1.7.3
+FROM    openshift/origin-release:golang-1.7
 WORKDIR /go/src/github.com/juliusv/message-buffer
 ADD     . /go/src/github.com/juliusv/message-buffer
 RUN     CGO_ENABLED=0 GOOS=linux go install -a -installsuffix cgo .


### PR DESCRIPTION
Openshift related images are migrating their base images to use the official Openshift Golang 1.7 base image; we should include **message-buffer** with this trend